### PR TITLE
Fix not working on minikube

### DIFF
--- a/kustomize/deployment.yaml
+++ b/kustomize/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         app: workspace
     spec:
+      serviceAccountName: common-spark-sa
       containers:
         - name: jupyter-lab
           image: kanchishimono/pyspark-jupyter:master

--- a/kustomize/ingress.yaml
+++ b/kustomize/ingress.yaml
@@ -6,21 +6,21 @@ metadata:
     app: workspace
 spec:
   rules:
-    - host: jupyter-lab.localhost
+    - host: jupyter-lab.local
       http:
         paths:
           - path: /
             backend:
               serviceName: svc
               servicePort: 8888
-    - host: spark-ui.localhost
+    - host: spark-ui.local
       http:
         paths:
           - path: /
             backend:
               serviceName: svc
               servicePort: 4040
-    - host: history-server.localhost
+    - host: history-server.local
       http:
         paths:
           - path: /

--- a/kustomize/kustomization.yaml
+++ b/kustomize/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - service.yaml
   - ingress.yaml
   - deployment.yaml
+  - rbac.yaml

--- a/kustomize/rbac.yaml
+++ b/kustomize/rbac.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: common-spark-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: common-spark-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit
+subjects:
+  - kind: ServiceAccount
+    name: common-spark-sa


### PR DESCRIPTION
Kustomization in this repository does not work on minikube.
I used Docker for Mac before, so Docker for Mac maybe adjust environment for working on local machine.
But minikube does not work on the same kustomization.


## Changes

- Change ingress hostname (Avoid to contain localhost)
- Add ServiceAccount (For creating spark worker pod by workspace)
